### PR TITLE
Add composer.json to allow install via composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "mavenlink/mavenlink_php_api",
+    "description": "Mavenlink PHP API Library",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Andrew Cantino",
+            "email": "cantino@users.noreply.github.com"
+        }
+    ],
+    "minimum-stability": "stable",
+    "require": {}
+}


### PR DESCRIPTION
Many popular modern PHP frameworks utilize composer to manage
dependencies. By including this file we allow users of those
frameworks to more easily integrate with the Mavenlink API in their
applications.